### PR TITLE
Fix potential invalid frees [minor]

### DIFF
--- a/lib/src/freq_scheduler.c
+++ b/lib/src/freq_scheduler.c
@@ -190,6 +190,7 @@ freq_scheduler_load_simple(FreqScheduler *sch,
                            float freq_scale) {
      char *error1 = 0;
      char *error2 = 0;
+     MDB_cursor *cursor = 0;
 
      HashInfoStream *st;
      if (hashinfo_stream_new(&st, sch->page_db) != 0) {
@@ -198,7 +199,6 @@ freq_scheduler_load_simple(FreqScheduler *sch,
           goto on_error;
      }
 
-     MDB_cursor *cursor;
      if (freq_scheduler_cursor_open(sch, &cursor) != 0)
 	  goto on_error;
 


### PR DESCRIPTION
I've started finding my way around the Aduana codebase in order to do a review, and I stumbled on a minor bug.

In a few places, the `goto on_error` cleanup pattern can skip over initialisations of variables that are freed in the code following the corresponding `on_error` label. Freeing an uninitialised variable is invalid, of course, and likely to cause a crash instead of gracefully handling the original error.

This is trivially fixed by moving declarations and adding initialisations where necessary