### PR TITLE
Replace abs() with llabs()

### DIFF
--- a/lib/src/util.c
+++ b/lib/src/util.c
@@ -168,7 +168,7 @@ varint_decode_uint64(uint8_t *in, uint8_t* read) {
 
 uint8_t*
 varint_encode_int64(int64_t n, uint8_t *out) {
-     return varint_encode_uint64(n >= 0? 2*n: 2*abs(n) + 1, out);
+     return varint_encode_uint64(n >= 0? 2*n: 2*llabs(n) + 1, out);
 }
 int64_t
 varint_decode_int64(uint8_t *in, uint8_t* read) {


### PR DESCRIPTION
`abs()` expects an `int`, but `varint_encode_int64()` passes it an `int64_t`, which can lead to implementation defined behaviour if `n` is larger than INT_MAX.

`long long int` is guaranteed to be at least 64-bits, so using `llabs()` avoids the above issue. Unfortunately, when `n` is INT64_MIN the result of `llabs()` is undefined, and this PR does not address that.