### PR TITLE
Suppress LMDB warnings in Debug, minor fixes

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(lmdb OBJECT
 include_directories(lib/lmdb)
 set_property(TARGET lmdb PROPERTY POSITION_INDEPENDENT_CODE 1)
 
+
 if(WIN32)
     add_library(mman OBJECT lib/mman.c)
     set_property(TARGET mman PROPERTY POSITION_INDEPENDENT_CODE 1)
@@ -60,6 +61,10 @@ endif(WIN32)
 # Tests
 #############################################################
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # LMDB generates quite a few warnings. Suppress them.
+  set_property(TARGET lmdb PROPERTY COMPILE_FLAGS
+    "-Wno-shadow -Wno-cast-align -Wno-unused-parameter -Wno-format-extra-args")
+
   add_definitions(-DTEST)
   include_directories(test)
   set(ADUANA_SRC ${ADUANA_SRC} test/CuTest.c)

--- a/lib/src/domain_temp.c
+++ b/lib/src/domain_temp.c
@@ -2,6 +2,8 @@
 #define _BSD_SOURCE 1
 #define _GNU_SOURCE 1
 
+#include <stdio.h>
+
 #include "domain_temp.h"
 
 DomainTemp *

--- a/lib/src/page_db.c
+++ b/lib/src/page_db.c
@@ -372,6 +372,9 @@ page_info_dump_get_score(MDB_val *val) {
 static PageInfo *
 page_info_load(const MDB_val *val) {
      PageInfo *pi = calloc(1, sizeof(*pi));
+     if (!pi)
+       return 0;
+
      char *data = val->mv_data;
      size_t i = 0;
      size_t j;

--- a/lib/src/scheduler.c
+++ b/lib/src/scheduler.c
@@ -42,6 +42,8 @@ page_request_new(size_t n_urls) {
      if (!req)
           return 0;
      req->urls = calloc(n_urls, sizeof(*req->urls));
+     if (!req->urls)
+          return 0;
      req->n_urls = 0;
 
      return req;


### PR DESCRIPTION
This PR adds the following small changes:
* Suppression of the warnings that lmdb spews during a Debug build via target property flags set in CMake (this works because appending `-Wno-foo` overrides `-Wfoo` if the latter is already present.)
  * I find that it's easier to miss important warnings when a third-party library produces lots of them. Happy to remove this commit if you don't like it.
* Two allocations are now checked for failure, where previously they had been missed.
* Include the stdio header in domain_temp.c since printf is used.